### PR TITLE
Forgot base_url argument in exposer.xml service

### DIFF
--- a/Resources/config/exposer.xml
+++ b/Resources/config/exposer.xml
@@ -5,7 +5,9 @@
     xsi:schemaLocation="http://symfony.com/schema/dic/services http://symfony.com/schema/dic/services/services-1.0.xsd">
 
     <services>
-        <service id="media_exposer" class="MediaExposer\Exposer" />
+        <service id="media_exposer" class="MediaExposer\Exposer">
+            <argument>%knplabs_media_exposer.exposer_base_url%</argument>
+        </service>
     </services>
 
 </container>


### PR DESCRIPTION
I found that even i use de knp_media_exposer.base_url parameters in my config.yml it's not pass to media_exposer service. It was a missing arg in exposer.xml file.
